### PR TITLE
Remove stylelint-config-prettier because it's not needed as of stylelint v15

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,3 @@
 module.exports = {
-  extends: ['stylelint-config-standard', 'stylelint-config-prettier'],
+  extends: ['stylelint-config-standard'],
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "MIT",
       "dependencies": {
         "stylelint": "15.1.0",
-        "stylelint-config-prettier": "9.0.4",
         "stylelint-config-standard": "30.0.1"
       },
       "devDependencies": {
@@ -1634,21 +1633,6 @@
         "url": "https://opencollective.com/stylelint"
       }
     },
-    "node_modules/stylelint-config-prettier": {
-      "version": "9.0.4",
-      "resolved": "https://registry.npmjs.org/stylelint-config-prettier/-/stylelint-config-prettier-9.0.4.tgz",
-      "integrity": "sha512-38nIGTGpFOiK5LjJ8Ma1yUgpKENxoKSOhbDNSemY7Ep0VsJoXIW9Iq/2hSt699oB9tReynfWicTAoIHiq8Rvbg==",
-      "bin": {
-        "stylelint-config-prettier": "bin/check.js",
-        "stylelint-config-prettier-check": "bin/check.js"
-      },
-      "engines": {
-        "node": ">= 12"
-      },
-      "peerDependencies": {
-        "stylelint": ">=11.0.0"
-      }
-    },
     "node_modules/stylelint-config-recommended": {
       "version": "10.0.1",
       "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-10.0.1.tgz",
@@ -2985,12 +2969,6 @@
         "v8-compile-cache": "^2.3.0",
         "write-file-atomic": "^5.0.0"
       }
-    },
-    "stylelint-config-prettier": {
-      "version": "9.0.4",
-      "resolved": "https://registry.npmjs.org/stylelint-config-prettier/-/stylelint-config-prettier-9.0.4.tgz",
-      "integrity": "sha512-38nIGTGpFOiK5LjJ8Ma1yUgpKENxoKSOhbDNSemY7Ep0VsJoXIW9Iq/2hSt699oB9tReynfWicTAoIHiq8Rvbg==",
-      "requires": {}
     },
     "stylelint-config-recommended": {
       "version": "10.0.1",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
   "license": "MIT",
   "dependencies": {
     "stylelint": "15.1.0",
-    "stylelint-config-prettier": "9.0.4",
     "stylelint-config-standard": "30.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Just upgraded Stylelint to v15. This version deprecates stylistic rules because prettier does it better. We already use prettier in our projects for stylistic changes. The `stylelint-config-prettier` was there to ignore all stylistic Stylelint rules already. This is not needed anymore now since there are no stylistic rules to ignore.

https://stylelint.io/migration-guide/to-15/#deprecated-stylistic-rules